### PR TITLE
chore: Bump various dependency versions for `sim`

### DIFF
--- a/endpoint/Dockerfile
+++ b/endpoint/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:20.04
 
 RUN apt-get update && \
   apt-get install -y wget net-tools iputils-ping tcpdump ethtool iperf iproute2

--- a/endpoint/Dockerfile
+++ b/endpoint/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
   apt-get install -y wget net-tools iputils-ping tcpdump ethtool iperf iproute2

--- a/sim/CMakeLists.patch
+++ b/sim/CMakeLists.patch
@@ -1,11 +1,26 @@
---- /Users/lars/Downloads/CMakeLists.txt	2023-12-21 15:49:55
-+++ CMakeLists.txt	2023-12-21 16:00:19
-@@ -105,7 +105,7 @@
-   else()
-     # Otherwise we pick all the files in the subdirectory
-     # and create a scratch for them automatically
--    file(GLOB scratch_sources CONFIGURE_DEPENDS ${subdir}/[^.]*.cc)
-+    file(GLOB scratch_sources CONFIGURE_DEPENDS ${subdir}/[^.]*.cc helper/[^.]*.cc)
-     create_scratch("${scratch_sources}")
+diff --git a/scratch/CMakeLists.txt b/scratch/CMakeLists.txt
+index adeeb2cf8..6e23f81b6 100644
+--- a/scratch/CMakeLists.txt
++++ b/scratch/CMakeLists.txt
+@@ -58,6 +58,11 @@ function(create_scratch source_files)
+     set(target_prefix scratch${scratch_dirname}_)
+   endif()
+ 
++  # Link our scratches against the helper files
++  get_filename_component(scratch_dirname ${scratch_src} DIRECTORY)
++  file(GLOB helper_files CONFIGURE_DEPENDS ${scratch_dirname}/../helper/*)
++  list(APPEND source_files ${helper_files})
++
+   # Get source absolute path and transform into relative path
+   get_filename_component(scratch_src ${scratch_src} ABSOLUTE)
+   get_filename_component(scratch_absolute_directory ${scratch_src} DIRECTORY)
+@@ -88,7 +93,8 @@ file(
+ )
+ # Filter out files
+ foreach(entry ${scratch_subdirectories})
+-  if(NOT (IS_DIRECTORY ${entry}))
++  # Don't treat our helper directory as a scratch
++  if(NOT (IS_DIRECTORY ${entry}) OR ${entry} MATCHES ".*/helper")
+     list(REMOVE_ITEM scratch_subdirectories ${entry})
    endif()
  endforeach()

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -5,16 +5,18 @@ RUN echo "TARGETARCH : $TARGETARCH"
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
-  python3 build-essential cmake wget ninja-build libboost-dev libgsl-dev libxml2-dev \
+  python3 build-essential cmake ninja-build libboost-dev libgsl-dev libxml2-dev \
   libsqlite3-dev
 
 ENV NS_VERS 3.41
-RUN wget -O ns3.tar.bz2 https://www.nsnam.org/release/ns-allinone-$NS_VERS.tar.bz2
+ADD --checksum=sha256:ce6a2c6a91d6979999da0a889cf0aa5db8798f387edf20672af9bcd966277aa9 \
+  https://www.nsnam.org/release/ns-allinone-$NS_VERS.tar.bz2 ns3.tar.bz2
 RUN tar xjf ns3.tar.bz2 && rm ns3.tar.bz2
 RUN mv /ns-allinone-$NS_VERS/ns-$NS_VERS /ns3
 
 ENV GO_VERS 1.22.3
-RUN wget -O go.tar.gz https://dl.google.com/go/go$GO_VERS.linux-$TARGETARCH.tar.gz
+ADD --checksum=sha256:6c33e52a5b26e7aa021b94475587fce80043a727a54ceb0eee2f9fc160646434 \
+  https://dl.google.com/go/go$GO_VERS.linux-$TARGETARCH.tar.gz go.tar.gz
 RUN tar xfz go.tar.gz && rm go.tar.gz
 
 WORKDIR /ns3

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
   python3 build-essential cmake ninja-build libboost-dev libgsl-dev libxml2-dev \
   libsqlite3-dev golang-go
 
-ENV NS_VERS 3.41
+ENV NS_VERS 3.42
 ADD --checksum=sha256:ce6a2c6a91d6979999da0a889cf0aa5db8798f387edf20672af9bcd966277aa9 \
   https://www.nsnam.org/release/ns-allinone-$NS_VERS.tar.bz2 ns3.tar.bz2
 RUN tar xjf ns3.tar.bz2 && rm ns3.tar.bz2

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -1,17 +1,19 @@
-FROM ubuntu:22.04 AS builder
+FROM ubuntu:24.04 AS builder
 
 ARG TARGETARCH
 RUN echo "TARGETARCH : $TARGETARCH"
 
 RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y python3 build-essential cmake wget ninja-build
+  DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  python3 build-essential cmake wget ninja-build libboost-dev libgsl-dev libxml2-dev \
+  libsqlite3-dev
 
-ENV NS_VERS 3.40
+ENV NS_VERS 3.41
 RUN wget -O ns3.tar.bz2 https://www.nsnam.org/release/ns-allinone-$NS_VERS.tar.bz2
 RUN tar xjf ns3.tar.bz2 && rm ns3.tar.bz2
 RUN mv /ns-allinone-$NS_VERS/ns-$NS_VERS /ns3
 
-ENV GO_VERS 1.21.5
+ENV GO_VERS 1.22.3
 RUN wget -O go.tar.gz https://dl.google.com/go/go$GO_VERS.linux-$TARGETARCH.tar.gz
 RUN tar xfz go.tar.gz && rm go.tar.gz
 
@@ -23,8 +25,6 @@ RUN ./ns3 configure --build-profile=release --out=out/
 # make including of the QuicNetworkSimulatorHelper class possible
 COPY CMakeLists.patch .
 RUN patch -d scratch < CMakeLists.patch
-
-RUN rm -r scratch/subdir scratch/scratch-simulator.cc
 COPY scenarios scratch/
 
 # compile all the scenarios
@@ -32,14 +32,14 @@ RUN ./ns3 build
 
 # strip ns3 version prefix from scratches
 RUN find out/scratch -name "ns${NS_VERS}-*" | \
-    sed -e 'p' -E -e "s|ns${NS_VERS}-*||g" | \
-    xargs -n2 mv
+  sed -e 'p' -E -e "s|ns${NS_VERS}-*||g" | \
+  xargs -n2 mv
 
 ENV PATH="/go/bin:${PATH}"
 COPY wait-for-it-quic /wait-for-it-quic
 RUN cd /wait-for-it-quic && go build .
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
   apt-get install -y net-tools iptables && \

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
   libsqlite3-dev golang-go
 
 ENV NS_VERS 3.42
-ADD --checksum=sha256:ce6a2c6a91d6979999da0a889cf0aa5db8798f387edf20672af9bcd966277aa9 \
+ADD --checksum=sha256:90600b3fb73b00f477c8b82c04639b1fd79b8a1cfd3c46236e3c9a3c8d3bcb62 \
   https://www.nsnam.org/release/ns-allinone-$NS_VERS.tar.bz2 ns3.tar.bz2
 RUN tar xjf ns3.tar.bz2 && rm ns3.tar.bz2
 RUN mv /ns-allinone-$NS_VERS/ns-$NS_VERS /ns3

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -27,13 +27,18 @@ COPY scenarios scratch/
 # compile all the scenarios
 RUN ./ns3 build
 
+# strip ns3 version prefix from scratches
+RUN find out/scratch -name "ns${NS_VERS}-*" | \
+    sed -e 'p' -E -e "s|ns${NS_VERS}-*||g" | \
+    xargs -n2 mv
+
 COPY wait-for-it-quic /wait-for-it-quic
 RUN cd /wait-for-it-quic && go build .
 
 FROM ubuntu:24.04
 
 RUN apt-get update && \
-  apt-get install -y net-tools iptables && \
+  apt-get install -y net-tools iptables libgsl-dev libxml2 libsqlite3-0 && \
   apt-get clean
 
 WORKDIR /ns3

--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -6,18 +6,13 @@ RUN echo "TARGETARCH : $TARGETARCH"
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \
   python3 build-essential cmake ninja-build libboost-dev libgsl-dev libxml2-dev \
-  libsqlite3-dev
+  libsqlite3-dev golang-go
 
 ENV NS_VERS 3.41
 ADD --checksum=sha256:ce6a2c6a91d6979999da0a889cf0aa5db8798f387edf20672af9bcd966277aa9 \
   https://www.nsnam.org/release/ns-allinone-$NS_VERS.tar.bz2 ns3.tar.bz2
 RUN tar xjf ns3.tar.bz2 && rm ns3.tar.bz2
 RUN mv /ns-allinone-$NS_VERS/ns-$NS_VERS /ns3
-
-ENV GO_VERS 1.22.3
-ADD --checksum=sha256:6c33e52a5b26e7aa021b94475587fce80043a727a54ceb0eee2f9fc160646434 \
-  https://dl.google.com/go/go$GO_VERS.linux-$TARGETARCH.tar.gz go.tar.gz
-RUN tar xfz go.tar.gz && rm go.tar.gz
 
 WORKDIR /ns3
 
@@ -32,12 +27,6 @@ COPY scenarios scratch/
 # compile all the scenarios
 RUN ./ns3 build
 
-# strip ns3 version prefix from scratches
-RUN find out/scratch -name "ns${NS_VERS}-*" | \
-  sed -e 'p' -E -e "s|ns${NS_VERS}-*||g" | \
-  xargs -n2 mv
-
-ENV PATH="/go/bin:${PATH}"
 COPY wait-for-it-quic /wait-for-it-quic
 RUN cd /wait-for-it-quic && go build .
 


### PR DESCRIPTION
* sim docker image to ubuntu:24.04
* ns-3 to 3.42
* go to 1.22 (via `apt`)
