### PR TITLE
Add burst parameter to DropRateErrorModel

### DIFF
--- a/sim/scenarios/drop-rate/README.md
+++ b/sim/scenarios/drop-rate/README.md
@@ -23,7 +23,7 @@ This scenario has the following configurable properties:
   parameter. For example, `--rate_to_client=10`.
 
 * `--burst_to_client`: The maximum number of packets that will be dropped in a
-  row in the server to client direction. This is a required parameter. For
+  row in the server to client direction. This is an optional parameter. For
   example, `--burst_to_client=3`.
 
 * `--rate_to_server`: Same as `rate_to_client` but in the other direction.

--- a/sim/scenarios/drop-rate/README.md
+++ b/sim/scenarios/drop-rate/README.md
@@ -3,7 +3,7 @@
 This scenario uses a bottleneck link similar to the [simple-p2p](../simple-p2p)
 scenario and optionally allows configuring the link to drop packets in either
 direction. Packets to be dropped are chosen randomly in both directions, based
-on rates specified by the user.
+on rates specified by the user, but no more than a given number of packets are dropped in a row.
 
 This scenario has the following configurable properties:
 
@@ -21,9 +21,14 @@ This scenario has the following configurable properties:
   (in percentage) in the server to client direction. This is a required
   parameter. For example, `--rate_to_client=10`.
 
+* `--burst_to_client`: The maximum number of packets that will be dropped in a row in the server to client direction. This is a required
+  parameter. For example, `--burst_to_client=3`.
+
 * `--rate_to_server`: Same as `rate_to_client` but in the other direction.
+
+* `--burst_to_server`: Same as `burst_to_client` but in the other direction.
 
 For example,
 ```bash
-./run.sh "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_client=10 --rate_to_server=20"
+./run.sh "drop-rate --delay=15ms --bandwidth=10Mbps --queue=25 --rate_to_client=10 --rate_to_server=20 --burst_to_client=3 --burst_to_server=3"
 ```

--- a/sim/scenarios/drop-rate/README.md
+++ b/sim/scenarios/drop-rate/README.md
@@ -3,7 +3,8 @@
 This scenario uses a bottleneck link similar to the [simple-p2p](../simple-p2p)
 scenario and optionally allows configuring the link to drop packets in either
 direction. Packets to be dropped are chosen randomly in both directions, based
-on rates specified by the user, but no more than a given number of packets are dropped in a row.
+on rates specified by the user, but no more than a given number of packets are
+dropped in a row.
 
 This scenario has the following configurable properties:
 
@@ -21,8 +22,9 @@ This scenario has the following configurable properties:
   (in percentage) in the server to client direction. This is a required
   parameter. For example, `--rate_to_client=10`.
 
-* `--burst_to_client`: The maximum number of packets that will be dropped in a row in the server to client direction. This is a required
-  parameter. For example, `--burst_to_client=3`.
+* `--burst_to_client`: The maximum number of packets that will be dropped in a
+  row in the server to client direction. This is a required parameter. For
+  example, `--burst_to_client=3`.
 
 * `--rate_to_server`: Same as `rate_to_client` but in the other direction.
 

--- a/sim/scenarios/drop-rate/drop-rate-error-model.cc
+++ b/sim/scenarios/drop-rate/drop-rate-error-model.cc
@@ -1,41 +1,88 @@
-#include "../helper/quic-packet.h"
 #include "drop-rate-error-model.h"
+#include "../helper/quic-packet.h"
 
 using namespace std;
 
 NS_OBJECT_ENSURE_REGISTERED(DropRateErrorModel);
 
-TypeId DropRateErrorModel::GetTypeId(void) {
+TypeId DropRateErrorModel::GetTypeId(void)
+{
     static TypeId tid = TypeId("DropRateErrorModel")
-        .SetParent<ErrorModel>()
-        .AddConstructor<DropRateErrorModel>()
-        ;
+                            .SetParent<ErrorModel>()
+                            .AddConstructor<DropRateErrorModel>();
     return tid;
 }
- 
+
 DropRateErrorModel::DropRateErrorModel()
-    : rate(0), distr(0, 99) {
-    std::random_device rd;
-    rng = new std::mt19937(rd());
+{
+    rate = 0;
+    burst = 0;
+    dropped_in_a_row = 0;
+    dropped = 0;
+    forwarded = 0;
 }
 
-void DropRateErrorModel::DoReset(void) { }
- 
-bool DropRateErrorModel::DoCorrupt(Ptr<Packet> p) {
-    if(!IsUDPPacket(p)) return false;
+DropRateErrorModel::~DropRateErrorModel()
+{
+    cout << "Dropped " << dropped << " packets, forwarded " << forwarded
+         << " packets (" << (double)dropped / (dropped + forwarded) * 100
+         << "%)." << endl
+         << flush;
+}
+
+void DropRateErrorModel::DoReset(void)
+{
+    dropped_in_a_row = 0;
+    dropped = 0;
+    forwarded = 0;
+}
+
+bool DropRateErrorModel::DoCorrupt(Ptr<Packet> p)
+{
+    if (!IsUDPPacket(p))
+        return false;
+
+    bool shouldDrop = false;
+    if (dropped_in_a_row >= burst) {
+        dropped_in_a_row = 0;
+        shouldDrop = false;
+    } else if (std::rand() % 100 < rate) {
+        dropped_in_a_row++;
+        shouldDrop = true;
+    } else {
+        dropped_in_a_row = 0;
+        shouldDrop = false;
+    }
 
     QuicPacket qp = QuicPacket(p);
 
-    if (distr(*rng) >= rate) {
-        cout << "Forwarding packet (" << qp.GetUdpPayload().size() << " bytes) from " << qp.GetIpv4Header().GetSource() << endl;
+    if (shouldDrop) {
+        cout << "Dropping packet (" << qp.GetUdpPayload().size()
+             << " bytes) from " << qp.GetIpv4Header().GetSource() << ":"
+             << qp.GetUdpHeader().GetSourcePort() << " to "
+             << qp.GetIpv4Header().GetDestination() << ":"
+             << qp.GetUdpHeader().GetDestinationPort() << endl
+             << flush;
+        dropped++;
+    } else {
+        cout << "Forwarding packet (" << qp.GetUdpPayload().size()
+             << " bytes) from " << qp.GetIpv4Header().GetSource() << ":"
+             << qp.GetUdpHeader().GetSourcePort() << " to "
+             << qp.GetIpv4Header().GetDestination() << ":"
+             << qp.GetUdpHeader().GetDestinationPort() << endl
+             << flush;
+        forwarded++;
         qp.ReassemblePacket();
-        return false;
     }
-
-    cout << "Dropping packet (" << qp.GetUdpPayload().size() << " bytes) from " << qp.GetIpv4Header().GetSource() << endl;
-    return true;
+    return shouldDrop;
 }
 
-void DropRateErrorModel::SetDropRate(int rate_in) {
+void DropRateErrorModel::SetDropRate(int rate_in)
+{
     rate = rate_in;
+}
+
+void DropRateErrorModel::SetMaxDropBurst(int burst_in)
+{
+    burst = burst_in;
 }

--- a/sim/scenarios/drop-rate/drop-rate-error-model.cc
+++ b/sim/scenarios/drop-rate/drop-rate-error-model.cc
@@ -5,30 +5,24 @@ using namespace std;
 
 NS_OBJECT_ENSURE_REGISTERED(DropRateErrorModel);
 
-TypeId DropRateErrorModel::GetTypeId(void)
-{
+TypeId DropRateErrorModel::GetTypeId(void) {
     static TypeId tid = TypeId("DropRateErrorModel")
-                            .SetParent<ErrorModel>()
-                            .AddConstructor<DropRateErrorModel>();
+        .SetParent<ErrorModel>()
+        .AddConstructor<DropRateErrorModel>()
+        ;
     return tid;
 }
 
-DropRateErrorModel::DropRateErrorModel()
-{
-    rate = 0;
-    burst = 0;
-    dropped_in_a_row = 0;
-    dropped = 0;
-    forwarded = 0;
-}
-
-DropRateErrorModel::~DropRateErrorModel()
-{
+DropRateErrorModel::~DropRateErrorModel() {
     cout << "Dropped " << dropped << " packets, forwarded " << forwarded
          << " packets (" << (double)dropped / (dropped + forwarded) * 100
          << "%)." << endl
          << flush;
 }
+
+DropRateErrorModel::DropRateErrorModel()
+    : rate(0), burst(0), dropped_in_a_row(0), dropped(0), forwarded(0)
+{}
 
 void DropRateErrorModel::DoReset(void)
 {
@@ -39,8 +33,7 @@ void DropRateErrorModel::DoReset(void)
 
 bool DropRateErrorModel::DoCorrupt(Ptr<Packet> p)
 {
-    if (!IsUDPPacket(p))
-        return false;
+    if(!IsUDPPacket(p)) return false;
 
     bool shouldDrop = false;
     if (dropped_in_a_row >= burst) {
@@ -77,12 +70,10 @@ bool DropRateErrorModel::DoCorrupt(Ptr<Packet> p)
     return shouldDrop;
 }
 
-void DropRateErrorModel::SetDropRate(int rate_in)
-{
+void DropRateErrorModel::SetDropRate(int rate_in) {
     rate = rate_in;
 }
 
-void DropRateErrorModel::SetMaxDropBurst(int burst_in)
-{
+void DropRateErrorModel::SetMaxDropBurst(int burst_in) {
     burst = burst_in;
 }

--- a/sim/scenarios/drop-rate/drop-rate-error-model.h
+++ b/sim/scenarios/drop-rate/drop-rate-error-model.h
@@ -1,8 +1,6 @@
 #ifndef DROPRATE_ERROR_MODEL_H
 #define DROPRATE_ERROR_MODEL_H
 
-#include <set>
-#include <random>
 #include "ns3/error-model.h"
 
 using namespace ns3;

--- a/sim/scenarios/drop-rate/drop-rate-error-model.h
+++ b/sim/scenarios/drop-rate/drop-rate-error-model.h
@@ -7,17 +7,23 @@
 
 using namespace ns3;
 
-// The DropRateErrorModel drops random packets, at a user-specified drop rate. 
+// The DropRateErrorModel drops random packets, at a user-specified drop rate.
+// But no more than a user-specified number of packets in a row.
 class DropRateErrorModel : public ErrorModel {
  public:
     static TypeId GetTypeId(void);
     DropRateErrorModel();
+    virtual ~DropRateErrorModel();
     void SetDropRate(int perc);
-    
- private:
+    void SetMaxDropBurst(int burst);
+
+  private:
     int rate;
-    std::mt19937 *rng;
-    std::uniform_int_distribution<> distr;
+    int next_rate;
+    int burst;
+    int dropped_in_a_row;
+    int dropped;
+    int forwarded;
 
     bool DoCorrupt (Ptr<Packet> p);
     void DoReset(void);

--- a/sim/scenarios/drop-rate/drop-rate-error-model.h
+++ b/sim/scenarios/drop-rate/drop-rate-error-model.h
@@ -11,7 +11,6 @@ class DropRateErrorModel : public ErrorModel {
  public:
     static TypeId GetTypeId(void);
     DropRateErrorModel();
-    virtual ~DropRateErrorModel();
     void SetDropRate(int perc);
     void SetMaxDropBurst(int burst);
 

--- a/sim/scenarios/drop-rate/drop-rate-error-model.h
+++ b/sim/scenarios/drop-rate/drop-rate-error-model.h
@@ -1,11 +1,13 @@
 #ifndef DROPRATE_ERROR_MODEL_H
 #define DROPRATE_ERROR_MODEL_H
 
+#include <set>
+#include <random>
 #include "ns3/error-model.h"
 
 using namespace ns3;
 
-// The DropRateErrorModel drops random packets, at a user-specified drop rate.
+// The DropRateErrorModel drops random packets, at a user-specified drop rate. 
 // But no more than a user-specified number of packets in a row.
 class DropRateErrorModel : public ErrorModel {
  public:
@@ -13,9 +15,11 @@ class DropRateErrorModel : public ErrorModel {
     DropRateErrorModel();
     void SetDropRate(int perc);
     void SetMaxDropBurst(int burst);
-
-  private:
+    
+ private:
     int rate;
+    std::mt19937 *rng;
+    std::uniform_int_distribution<> distr;
     int next_rate;
     int burst;
     int dropped_in_a_row;

--- a/sim/scenarios/drop-rate/drop-rate.cc
+++ b/sim/scenarios/drop-rate/drop-rate.cc
@@ -12,41 +12,40 @@ using namespace std;
 NS_LOG_COMPONENT_DEFINE("ns3 simulator");
 
 int main(int argc, char *argv[]) {
-    std::string delay, bandwidth, queue, client_rate, client_burst, server_rate,
-        server_burst;
-    std::srand(std::time(nullptr)); // Seed random number generator first
+    std::string delay, bandwidth, queue, client_rate, server_rate,
+        client_burst, server_burst;
+    std::random_device rand_dev;
+    std::mt19937 generator(rand_dev());  // Seed random number generator first
     Ptr<DropRateErrorModel> client_drops = CreateObject<DropRateErrorModel>();
     Ptr<DropRateErrorModel> server_drops = CreateObject<DropRateErrorModel>();
     CommandLine cmd;
-
+    
     cmd.AddValue("delay", "delay of the p2p link", delay);
     cmd.AddValue("bandwidth", "bandwidth of the p2p link", bandwidth);
     cmd.AddValue("queue", "queue size of the p2p link (in packets)", queue);
     cmd.AddValue("rate_to_client", "packet drop rate (towards client)", client_rate);
+    cmd.AddValue("rate_to_server", "packet drop rate (towards server)", server_rate);
     cmd.AddValue("burst_to_client",
                  "max. packet drop burst length (towards client)",
                  client_burst);
-    cmd.AddValue("rate_to_server", "packet drop rate (towards server)", server_rate);
     cmd.AddValue("burst_to_server",
                  "max. packet drop burst length (towards server)",
                  server_burst);
-    cmd.Parse(argc, argv);
-
+    cmd.Parse (argc, argv);
+    
     NS_ABORT_MSG_IF(delay.length() == 0, "Missing parameter: delay");
     NS_ABORT_MSG_IF(bandwidth.length() == 0, "Missing parameter: bandwidth");
     NS_ABORT_MSG_IF(queue.length() == 0, "Missing parameter: queue");
     NS_ABORT_MSG_IF(client_rate.length() == 0, "Missing parameter: rate_to_client");
-    NS_ABORT_MSG_IF(client_burst.length() == 0,
-                    "Missing parameter: burst_to_client");
     NS_ABORT_MSG_IF(server_rate.length() == 0, "Missing parameter: rate_to_server");
-    NS_ABORT_MSG_IF(server_burst.length() == 0,
-                    "Missing parameter: burst_to_server");
 
     // Set client and server drop rates and drop bursts.
     client_drops->SetDropRate(stoi(client_rate));
-    client_drops->SetMaxDropBurst(stoi(client_burst));
+    if (client_burst.length() > 0)
+        client_drops->SetMaxDropBurst(stoi(client_burst));
     server_drops->SetDropRate(stoi(server_rate));
-    server_drops->SetMaxDropBurst(stoi(server_burst));
+    if (server_burst.length() > 0)
+        server_drops->SetMaxDropBurst(stoi(server_burst));
 
     QuicNetworkSimulatorHelper sim;
 
@@ -55,11 +54,11 @@ int main(int argc, char *argv[]) {
     p2p.SetDeviceAttribute("DataRate", StringValue(bandwidth));
     p2p.SetChannelAttribute("Delay", StringValue(delay));
     p2p.SetQueueSize(StringValue(queue + "p"));
-
+    
     NetDeviceContainer devices = p2p.Install(sim.GetLeftNode(), sim.GetRightNode());
 
     devices.Get(0)->SetAttribute("ReceiveErrorModel", PointerValue(client_drops));
     devices.Get(1)->SetAttribute("ReceiveErrorModel", PointerValue(server_drops));
-
+    
     sim.Run(Seconds(36000));
 }

--- a/sim/scenarios/drop-rate/drop-rate.cc
+++ b/sim/scenarios/drop-rate/drop-rate.cc
@@ -12,29 +12,41 @@ using namespace std;
 NS_LOG_COMPONENT_DEFINE("ns3 simulator");
 
 int main(int argc, char *argv[]) {
-    std::string delay, bandwidth, queue, client_rate, server_rate;
-    std::random_device rand_dev;
-    std::mt19937 generator(rand_dev());  // Seed random number generator first
+    std::string delay, bandwidth, queue, client_rate, client_burst, server_rate,
+        server_burst;
+    std::srand(std::time(nullptr)); // Seed random number generator first
     Ptr<DropRateErrorModel> client_drops = CreateObject<DropRateErrorModel>();
     Ptr<DropRateErrorModel> server_drops = CreateObject<DropRateErrorModel>();
     CommandLine cmd;
-    
+
     cmd.AddValue("delay", "delay of the p2p link", delay);
     cmd.AddValue("bandwidth", "bandwidth of the p2p link", bandwidth);
     cmd.AddValue("queue", "queue size of the p2p link (in packets)", queue);
     cmd.AddValue("rate_to_client", "packet drop rate (towards client)", client_rate);
+    cmd.AddValue("burst_to_client",
+                 "max. packet drop burst length (towards client)",
+                 client_burst);
     cmd.AddValue("rate_to_server", "packet drop rate (towards server)", server_rate);
-    cmd.Parse (argc, argv);
-    
+    cmd.AddValue("burst_to_server",
+                 "max. packet drop burst length (towards server)",
+                 server_burst);
+    cmd.Parse(argc, argv);
+
     NS_ABORT_MSG_IF(delay.length() == 0, "Missing parameter: delay");
     NS_ABORT_MSG_IF(bandwidth.length() == 0, "Missing parameter: bandwidth");
     NS_ABORT_MSG_IF(queue.length() == 0, "Missing parameter: queue");
     NS_ABORT_MSG_IF(client_rate.length() == 0, "Missing parameter: rate_to_client");
+    NS_ABORT_MSG_IF(client_burst.length() == 0,
+                    "Missing parameter: burst_to_client");
     NS_ABORT_MSG_IF(server_rate.length() == 0, "Missing parameter: rate_to_server");
+    NS_ABORT_MSG_IF(server_burst.length() == 0,
+                    "Missing parameter: burst_to_server");
 
-    // Set client and server drop rates.
+    // Set client and server drop rates and drop bursts.
     client_drops->SetDropRate(stoi(client_rate));
+    client_drops->SetMaxDropBurst(stoi(client_burst));
     server_drops->SetDropRate(stoi(server_rate));
+    server_drops->SetMaxDropBurst(stoi(server_burst));
 
     QuicNetworkSimulatorHelper sim;
 
@@ -43,11 +55,11 @@ int main(int argc, char *argv[]) {
     p2p.SetDeviceAttribute("DataRate", StringValue(bandwidth));
     p2p.SetChannelAttribute("Delay", StringValue(delay));
     p2p.SetQueueSize(StringValue(queue + "p"));
-    
+
     NetDeviceContainer devices = p2p.Install(sim.GetLeftNode(), sim.GetRightNode());
 
     devices.Get(0)->SetAttribute("ReceiveErrorModel", PointerValue(client_drops));
     devices.Get(1)->SetAttribute("ReceiveErrorModel", PointerValue(server_drops));
-    
+
     sim.Run(Seconds(36000));
 }


### PR DESCRIPTION
This makes it so that the error model doesn't create loss bursts that are longer than the burst parameter. This should prevent idle timeouts when loss bursts are too long. It will however lower the overall loss rate below what is configured, because we're not adjusting the drop rate upward to compensate for breaking loss bursts (by forcing a forward).