### PR TITLE
Three minor fixes

### DIFF
--- a/sim/Dockerfile
+++ b/sim/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
   python3 build-essential cmake ninja-build libboost-dev libgsl-dev libxml2-dev \
   libsqlite3-dev golang-go
 
-ENV NS_VERS 3.42
+ENV NS_VERS=3.42
 ADD --checksum=sha256:90600b3fb73b00f477c8b82c04639b1fd79b8a1cfd3c46236e3c9a3c8d3bcb62 \
   https://www.nsnam.org/release/ns-allinone-$NS_VERS.tar.bz2 ns3.tar.bz2
 RUN tar xjf ns3.tar.bz2 && rm ns3.tar.bz2

--- a/sim/scenarios/drop-rate/drop-rate-error-model.h
+++ b/sim/scenarios/drop-rate/drop-rate-error-model.h
@@ -20,7 +20,6 @@ class DropRateErrorModel : public ErrorModel {
     int rate;
     std::mt19937 *rng;
     std::uniform_int_distribution<> distr;
-    int next_rate;
     int burst;
     int dropped_in_a_row;
     int dropped;

--- a/sim/scenarios/helper/quic-packet.cc
+++ b/sim/scenarios/helper/quic-packet.cc
@@ -69,17 +69,17 @@ bool QuicPacket::IsVersionNegotiationPacket() {
 
 void QuicPacket::ReassemblePacket() {
     // Start with the UDP payload.
-    Packet new_p = Packet(udp_payload_.data(), udp_payload_.size());
+    Packet * new_p = new Packet(udp_payload_.data(), udp_payload_.size());
     // Add the UDP header and make sure to recalculate the checksum.
     udp_hdr_.ForcePayloadSize(udp_payload_.size() + udp_hdr_len_);
     udp_hdr_.ForceChecksum(0);
     udp_hdr_.InitializeChecksum(ipv4_hdr_.GetSource(), ipv4_hdr_.GetDestination(), ipv4_hdr_.GetProtocol());
-    new_p.AddHeader(udp_hdr_);
+    new_p->AddHeader(udp_hdr_);
     // Add the IP header, again make sure to recalculate the checksum.
     ipv4_hdr_.EnableChecksum();
-    new_p.AddHeader(ipv4_hdr_);
+    new_p->AddHeader(ipv4_hdr_);
     // Add the PPP header.
-    new_p.AddHeader(ppp_hdr_);
+    new_p->AddHeader(ppp_hdr_);
     p_->RemoveAtEnd(p_->GetSize());
-    p_->AddAtEnd(Ptr<Packet>(&new_p));
+    p_->AddAtEnd(Ptr<Packet>(new_p));
 }


### PR DESCRIPTION
1. Fix the legacy `ENV` syntax in the Dockerfile.
2. Remove an unused variable from `DropRateErrorModel`.
3. Dynamically allocate `new_packet` in `QuicPacket::ReassemblePacket`.

The latter fixes several these warnings during the ns-3 compilation:
```
```